### PR TITLE
ACCUMULO-4086 Modified to fail upon misconfiguration instead of falli…

### DIFF
--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -548,7 +548,7 @@ public enum Property {
       + "replicate their data to. The key suffix is the identifying cluster name and the value is an identifier for a location on the target system, "
       + "e.g. the ID of the table on the target to replicate to"),
   @Experimental
-  TABLE_VOLUME_CHOOSER("table.volume.chooser", "", PropertyType.CLASSNAME,
+  TABLE_VOLUME_CHOOSER("table.volume.chooser", "org.apache.accumulo.server.fs.RandomVolumeChooser", PropertyType.CLASSNAME,
       "The class that will be used to select which volume will be used to create new files for this table. It needs to be set in the site configuration "
           + "and overridden per table, as needed"),
   TABLE_SAMPLER(

--- a/core/src/main/java/org/apache/accumulo/core/conf/Property.java
+++ b/core/src/main/java/org/apache/accumulo/core/conf/Property.java
@@ -191,7 +191,7 @@ public enum Property {
       + "server-internal scheduled tasks"),
   // If you update the default type, be sure to update the default used for initialization failures in VolumeManagerImpl
   @Experimental
-  GENERAL_VOLUME_CHOOSER("general.volume.chooser", "org.apache.accumulo.server.fs.RandomVolumeChooser", PropertyType.CLASSNAME,
+  GENERAL_VOLUME_CHOOSER("general.volume.chooser", "org.apache.accumulo.server.fs.PerTableVolumeChooser", PropertyType.CLASSNAME,
       "The class that will be used to select which volume will be used to create new files."),
   GENERAL_SECURITY_CREDENTIAL_PROVIDER_PATHS("general.security.credential.provider.paths", "", PropertyType.STRING,
       "Comma-separated list of paths to CredentialProviders"),

--- a/server/base/src/test/java/org/apache/accumulo/server/fs/PerTableVolumeChooserTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/fs/PerTableVolumeChooserTest.java
@@ -150,7 +150,7 @@ public class PerTableVolumeChooserTest {
     Assert.assertEquals(Sets.newHashSet(Arrays.asList("2")), results);
   }
 
-  @Test
+  @Test(expected = AccumuloException.class)
   public void testTableMisconfigured() throws Exception {
     configureDefaultVolumeChooser(VolumeChooserAlwaysOne.class.getName());
     configureChooserForTable(INVALID_CHOOSER_CLASSNAME);
@@ -160,10 +160,9 @@ public class PerTableVolumeChooserTest {
     Set<String> results = chooseRepeatedlyForTable();
 
     EasyMock.verify(mockedServerConfigurationFactory, mockedTableConfiguration, mockedAccumuloConfiguration);
-    Assert.assertEquals(Sets.newHashSet(Arrays.asList("1")), results);
   }
 
-  @Test
+  @Test(expected = AccumuloException.class)
   public void testTableMissing() throws Exception {
     configureDefaultVolumeChooser(VolumeChooserAlwaysOne.class.getName());
     configureChooserForTable(null);
@@ -173,7 +172,6 @@ public class PerTableVolumeChooserTest {
     Set<String> results = chooseRepeatedlyForTable();
 
     EasyMock.verify(mockedServerConfigurationFactory, mockedTableConfiguration, mockedAccumuloConfiguration);
-    Assert.assertEquals(Sets.newHashSet(Arrays.asList("1")), results);
   }
 
   @Test(expected = AccumuloException.class)
@@ -186,7 +184,7 @@ public class PerTableVolumeChooserTest {
     chooseRepeatedlyForTable();
   }
 
-  @Test
+  @Test(expected = AccumuloException.class)
   public void testTableEmptyConfig() throws Exception {
     configureDefaultVolumeChooser(VolumeChooserAlwaysThree.class.getName());
     configureChooserForTable("");
@@ -196,7 +194,6 @@ public class PerTableVolumeChooserTest {
     Set<String> results = chooseRepeatedlyForTable();
 
     EasyMock.verify(mockedServerConfigurationFactory, mockedTableConfiguration, mockedAccumuloConfiguration);
-    Assert.assertEquals(Sets.newHashSet(Arrays.asList("3")), results);
   }
 
   @Test(expected = AccumuloException.class)
@@ -222,7 +219,7 @@ public class PerTableVolumeChooserTest {
     Assert.assertEquals(Sets.newHashSet(Arrays.asList("1")), results);
   }
 
-  @Test
+  @Test(expected = AccumuloException.class)
   public void testContextMisconfigured() throws Exception {
     configureDefaultVolumeChooser(VolumeChooserAlwaysThree.class.getName());
     configureContextVolumeChooser(INVALID_CHOOSER_CLASSNAME);
@@ -232,7 +229,6 @@ public class PerTableVolumeChooserTest {
     Set<String> results = chooseRepeatedlyForContext();
 
     EasyMock.verify(mockedServerConfigurationFactory, mockedAccumuloConfiguration);
-    Assert.assertEquals(Sets.newHashSet(Arrays.asList("3")), results);
   }
 
   @Test
@@ -251,6 +247,7 @@ public class PerTableVolumeChooserTest {
   @Test(expected = AccumuloException.class)
   public void testContextMisconfiguredAndDefaultEmpty() throws Exception {
     configureDefaultVolumeChooser("");
+    configureChooserForTable("");
     configureContextVolumeChooser(INVALID_CHOOSER_CLASSNAME);
 
     EasyMock.replay(mockedServerConfigurationFactory, mockedAccumuloConfiguration);
@@ -268,7 +265,7 @@ public class PerTableVolumeChooserTest {
     chooseRepeatedlyForContext();
   }
 
-  @Test
+  @Test(expected = AccumuloException.class)
   public void testContextEmptyConfig() throws Exception {
     configureDefaultVolumeChooser(VolumeChooserAlwaysTwo.class.getName());
     configureContextVolumeChooser("");
@@ -278,6 +275,5 @@ public class PerTableVolumeChooserTest {
     Set<String> results = chooseRepeatedlyForContext();
 
     EasyMock.verify(mockedServerConfigurationFactory, mockedAccumuloConfiguration);
-    Assert.assertEquals(Sets.newHashSet(Arrays.asList("2")), results);
   }
 }

--- a/server/base/src/test/java/org/apache/accumulo/server/fs/PreferredVolumeChooserTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/fs/PreferredVolumeChooserTest.java
@@ -111,7 +111,7 @@ public class PreferredVolumeChooserTest {
     Assert.assertEquals(Sets.newHashSet(Arrays.asList("1", "2")), results);
   }
 
-  @Test
+  @Test(expected = AccumuloException.class)
   public void testTableMisconfigured() throws Exception {
     configureDefaultVolumes("1,3");
     configureTableVolumes("4");
@@ -124,7 +124,7 @@ public class PreferredVolumeChooserTest {
     Assert.assertEquals(Sets.newHashSet(Arrays.asList("1", "3")), results);
   }
 
-  @Test
+  @Test(expected = AccumuloException.class)
   public void testTableMissing() throws Exception {
     configureDefaultVolumes("1,3");
     configureTableVolumes(null);
@@ -137,7 +137,7 @@ public class PreferredVolumeChooserTest {
     Assert.assertEquals(Sets.newHashSet(Arrays.asList("1", "3")), results);
   }
 
-  @Test
+  @Test(expected = AccumuloException.class)
   public void testTableEmptyConfig() throws Exception {
     configureDefaultVolumes("1,3");
     configureTableVolumes("");
@@ -183,7 +183,7 @@ public class PreferredVolumeChooserTest {
     Assert.assertEquals(Sets.newHashSet(Arrays.asList("1", "2")), results);
   }
 
-  @Test
+  @Test(expected = AccumuloException.class)
   public void testContextMisconfigured() throws Exception {
     configureDefaultVolumes("1,3");
     configureContextVolumes("4");
@@ -196,7 +196,7 @@ public class PreferredVolumeChooserTest {
     Assert.assertEquals(Sets.newHashSet(Arrays.asList("1", "3")), results);
   }
 
-  @Test
+  @Test(expected = AccumuloException.class)
   public void testContextMissing() throws Exception {
     configureDefaultVolumes("1,3");
     configureContextVolumes(null);
@@ -229,7 +229,7 @@ public class PreferredVolumeChooserTest {
     chooseRepeatedlyForContext();
   }
 
-  @Test
+  @Test(expected = AccumuloException.class)
   public void testContextEmptyConfig() throws Exception {
     configureDefaultVolumes("1,3");
     configureContextVolumes("");

--- a/server/base/src/test/java/org/apache/accumulo/server/fs/VolumeManagerImplTest.java
+++ b/server/base/src/test/java/org/apache/accumulo/server/fs/VolumeManagerImplTest.java
@@ -16,10 +16,6 @@
  */
 package org.apache.accumulo.server.fs;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.server.fs.VolumeManager.FileType;
@@ -28,6 +24,10 @@ import org.apache.hadoop.fs.Path;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 
 /**
  *
@@ -61,7 +61,7 @@ public class VolumeManagerImplTest {
     fs.getFullPath(FileType.TABLE, "/t-0000001/C0000001.rf");
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test(expected = RuntimeException.class)
   public void invalidChooserConfigured() throws Exception {
     List<String> volumes = Arrays.asList("file://one/", "file://two/", "file://three/");
     ConfigurationCopy conf = new ConfigurationCopy();
@@ -114,7 +114,8 @@ public class VolumeManagerImplTest {
   @SuppressWarnings("deprecation")
   private static final Property INSTANCE_DFS_URI = Property.INSTANCE_DFS_URI;
 
-  @Test
+  // Expected to throw a runtime exception when the WrongVolumeChooser picks an invalid volume.
+  @Test(expected = RuntimeException.class)
   public void chooseFromOptions() throws Exception {
     List<String> volumes = Arrays.asList("file://one/", "file://two/", "file://three/");
     ConfigurationCopy conf = new ConfigurationCopy();
@@ -124,6 +125,5 @@ public class VolumeManagerImplTest {
     VolumeManager vm = VolumeManagerImpl.get(conf);
     VolumeChooserEnvironment chooserEnv = new VolumeChooserEnvironment(Optional.of("sometable"));
     String choice = vm.choose(chooserEnv, volumes.toArray(new String[0]));
-    Assert.assertTrue("shouldn't see invalid options from misbehaving chooser.", volumes.contains(choice));
   }
 }

--- a/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/RootFilesTest.java
+++ b/server/tserver/src/test/java/org/apache/accumulo/tserver/tablet/RootFilesTest.java
@@ -29,6 +29,7 @@ import org.apache.accumulo.core.conf.AccumuloConfiguration;
 import org.apache.accumulo.core.conf.ConfigurationCopy;
 import org.apache.accumulo.core.conf.Property;
 import org.apache.accumulo.server.fs.FileRef;
+import org.apache.accumulo.server.fs.RandomVolumeChooser;
 import org.apache.accumulo.server.fs.VolumeManager;
 import org.apache.accumulo.server.fs.VolumeManagerImpl;
 import org.apache.hadoop.fs.Path;
@@ -123,6 +124,7 @@ public class RootFilesTest {
     ConfigurationCopy conf = new ConfigurationCopy();
     conf.set(Property.INSTANCE_DFS_URI, "file:///");
     conf.set(Property.INSTANCE_DFS_DIR, "/");
+    conf.set(Property.GENERAL_VOLUME_CHOOSER, RandomVolumeChooser.class.getName());
 
     VolumeManager vm = VolumeManagerImpl.get(conf);
 


### PR DESCRIPTION
I added code that I believe reflects all of the review comments.  The general idea is now to fail when something is not configured correctly.  The only thing that bothers me now is that if the PerTableVolumeChooser is the default, then we probably should not set the default for the custom table chooser to be empty.