### PR TITLE
Fix bug with invalid input to getOpt and stop-here

### DIFF
--- a/assemble/bin/accumulo-cluster
+++ b/assemble/bin/accumulo-cluster
@@ -80,6 +80,11 @@ function parse_args {
   ARG_COMPACTOR_GROUP=""
 
   PARSE_OUTPUT=$(getopt -o "" --long "dry-run,all,local,manager,gc,monitor,compaction-coordinator,no-tservers,tservers,sservers::,compactors::" -n 'accumulo-cluster' -- "$@")
+  if [[ "$?" != 0 ]]; then
+    print_usage
+    exit 1
+  fi
+
   eval set -- "$PARSE_OUTPUT"
 
   while true; do
@@ -405,7 +410,7 @@ function control_services() {
   local group
   local tserver
   local G
-  if [[ $ARG_ALL == 1 && $operation == "stop" ]]; then
+  if [[ $ARG_ALL == 1 && $ARG_LOCAL == 0 && $operation == "stop" ]]; then
     echo "Stopping Accumulo cluster..."
     if ! isDebug; then
       if ! $accumulo_cmd admin stopAll; then


### PR DESCRIPTION
Fixes a bug where getopt would remove invalid options and continue. This would cause the following command to run and stop the whole accumulo cluster: `./accumulo-cluster stop --compcators`

Also fixes an issue where `stop-here` would communicate with the accumulo manager and gracefully stop all tservers.